### PR TITLE
Use Tanstack React Query for fetching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import type { LatLngTuple } from 'leaflet';
-import { useState, useEffect } from 'react';
-import { useCable } from './hooks/useCable';
+import { useState, useEffect, Suspense } from 'react';
 import Map from './components/Map';
 import UptimeTimeline from './components/UptimeTimeline';
 import About from './components/About';
@@ -23,7 +22,6 @@ function App() {
   const [isTimelineOpen, setIsTimelineOpen] = useState(false);
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
-  const cables = useCable();
   const [mapCenter, setMapCenter] = useState<LatLngTuple>(
     window.innerWidth < 768 ? mobileMapCenter : window.innerWidth < 1024 ? midwidthMapCenter : desktopMapCenter
   );
@@ -81,11 +79,12 @@ function App() {
             onClose={handleCloseTimeline}
             title={t('timeline.title')}
           >
+          <Suspense>
             <UptimeTimeline
-              cables={cables}
               startDate={timelineRange}
               endDate={now}
             />
+          </Suspense>
           </Modal>
           <Modal
             isOpen={isAboutOpen}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import type { LatLngTuple } from 'leaflet';
 import { useState, useEffect } from 'react';
+import { useCable } from './hooks/useCable';
 import Map from './components/Map';
 import UptimeTimeline from './components/UptimeTimeline';
 import About from './components/About';
@@ -22,7 +23,7 @@ function App() {
   const [isTimelineOpen, setIsTimelineOpen] = useState(false);
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
-  const [cables, setCables] = useState<{ id: string, name: string }[]>([]);
+  const cables = useCable();
   const [mapCenter, setMapCenter] = useState<LatLngTuple>(
     window.innerWidth < 768 ? mobileMapCenter : window.innerWidth < 1024 ? midwidthMapCenter : desktopMapCenter
   );
@@ -35,23 +36,6 @@ function App() {
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  useEffect(() => {
-    // Dynamically import cable data to pass to timeline
-    const loadCables = async () => {
-      const cableFiles = import.meta.glob<{ default: { id: string, name: string } }>('/src/data/cables/*.json');
-      const loadedCables = [];
-      for (const path in cableFiles) {
-        const module = await cableFiles[path]();
-        loadedCables.push({
-          id: module.default.id,
-          name: module.default.name
-        });
-      }
-      setCables(loadedCables);
-    };
-    loadCables();
   }, []);
 
   const handleOpenTimeline = () => setIsTimelineOpen(true);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,9 @@ function App() {
             </button>
           )}
           <div className={`incident-section ${isMobile ? 'full-width' : ''}`}>
-            <IncidentList />
+            <Suspense>
+              <IncidentList />
+            </Suspense>
           </div>
           <Modal
             isOpen={isTimelineOpen}

--- a/src/components/CableLayer.tsx
+++ b/src/components/CableLayer.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { Polyline, Marker, Popup } from 'react-leaflet';
 import { Icon } from 'leaflet';
-import type { LatLngExpression, PopupEvent } from 'leaflet';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import type { PopupEvent } from 'leaflet';
 import { useIncidents, type Incident } from '../hooks/useIncidents';
+import { useCable, type Cable, type Segment } from '../hooks/useCable';
 
 // Re-use the white dot icon from Map.tsx
 const whiteDotIcon = new Icon({
@@ -11,28 +11,6 @@ const whiteDotIcon = new Icon({
   iconSize: [12, 12],
   iconAnchor: [6, 6]
 });
-
-interface Segment {
-  id: string;
-  hidden?: boolean;
-  coordinates: LatLngExpression[];
-  color?: string;
-}
-
-interface Equipment {
-  id: string;
-  name: string;
-  coordinate: [number, number];
-}
-
-interface Cable {
-  id: string;
-  name: string;
-  color?: string;
-  segments: Segment[];
-  equipments?: Equipment[];
-  available_path?: string[][];
-}
 
 function markBroken(paths: string[][], inputNodes: string[]) {
   const failedPaths = new Set<string>();
@@ -129,24 +107,9 @@ function InteractivePolyline({ cable, segment, incidents }: { cable: Cable; segm
   );
 }
 
-async function loadCables(): Promise<Cable[]> {
-  const modules = import.meta.glob('../data/cables/*.json');
-  const cablePromises = Object.values(modules).map(async (loader) => {
-    const module = await loader();
-    return (module as { default: Cable }).default;
-  });
-  return Promise.all(cablePromises);
-}
-
 export default function CableLayer() {
   const incidents = useIncidents();
-
-  const { data: cables } = useSuspenseQuery({
-    queryKey: ['cables'],
-    queryFn: async (): Promise<Cable[]> => {
-      return await loadCables();
-    },
-  });
+  const cables = useCable();
 
   return (
     <>

--- a/src/components/IncidentList.tsx
+++ b/src/components/IncidentList.tsx
@@ -1,36 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useIncidents } from '../hooks/useIncidents';
 import './IncidentList.css';
-
-interface Incident {
-  date: string;
-  status: string;
-  cableid: string;
-  segment: string;
-  title: string;
-  description: string;
-  reparing_at: string;
-  resolved_at: string;
-}
 
 export default function IncidentList() {
   const { t } = useTranslation();
-  const [incidents, setIncidents] = useState<Incident[]>([]);
+  const incidents = useIncidents();
   const [showHistorical, setShowHistorical] = useState(false);
-
-  useEffect(() => {
-    // Load incidents from JSON file
-    fetch('/data/incidents.json')
-      .then(response => response.json())
-      .then((data: Incident[]) => {
-        // Sort incidents by date, most recent first
-        const sortedIncidents = data.sort((a, b) => 
-          new Date(b.date).getTime() - new Date(a.date).getTime()
-        );
-        setIncidents(sortedIncidents);
-      })
-      .catch(error => console.error('Error loading incidents:', error));
-  }, []);
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import { Icon } from 'leaflet';
 import type { LatLngExpression } from 'leaflet';
@@ -39,7 +40,9 @@ export default function Map({ center }: MapProps) {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
           url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
         />
-        <CableLayer />
+        <Suspense>
+          <CableLayer />
+        </Suspense>
         
         {/* Render landing points */}
         {landingPoints.map((point) => (

--- a/src/components/UptimeTimeline.tsx
+++ b/src/components/UptimeTimeline.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { useIncidents } from '../hooks/useIncidents';
 import { useTimelineSegments } from '../hooks/useTimelineSegments';
-import './UptimeTimeline.css';
 import { useCable } from '../hooks/useCable';
+import './UptimeTimeline.css';
 
 interface UptimeTimelineProps {
   startDate: Date;

--- a/src/components/UptimeTimeline.tsx
+++ b/src/components/UptimeTimeline.tsx
@@ -2,20 +2,16 @@ import { useTranslation } from 'react-i18next';
 import { useIncidents } from '../hooks/useIncidents';
 import { useTimelineSegments } from '../hooks/useTimelineSegments';
 import './UptimeTimeline.css';
-
-interface Cable {
-  id: string;
-  name: string;
-}
+import { useCable } from '../hooks/useCable';
 
 interface UptimeTimelineProps {
-  cables: Cable[];
   startDate: Date;
   endDate: Date;
 }
 
-export default function UptimeTimeline({ cables, startDate, endDate }: UptimeTimelineProps) {
+export default function UptimeTimeline({ startDate, endDate }: UptimeTimelineProps) {
   const { t } = useTranslation();
+  const cables = useCable();
   const incidents = useIncidents();
   const segments = useTimelineSegments({ cables, incidents, startDate, endDate });
 

--- a/src/hooks/useCable.ts
+++ b/src/hooks/useCable.ts
@@ -1,0 +1,44 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import type { LatLngExpression } from "leaflet";
+
+export interface Segment {
+  id: string;
+  hidden?: boolean;
+  coordinates: LatLngExpression[];
+  color?: string;
+}
+
+export interface Equipment {
+  id: string;
+  name: string;
+  coordinate: [number, number];
+}
+
+export interface Cable {
+  id: string;
+  name: string;
+  color?: string;
+  segments: Segment[];
+  equipments?: Equipment[];
+  available_path?: string[][];
+}
+
+async function loadCables(): Promise<Cable[]> {
+  const modules = import.meta.glob("../data/cables/*.json");
+  const cablePromises = Object.values(modules).map(async (loader) => {
+    const module = await loader();
+    return (module as { default: Cable }).default;
+  });
+  return Promise.all(cablePromises);
+}
+
+export function useCable() {
+  const { data: cables } = useSuspenseQuery({
+    queryKey: ["cables"],
+    queryFn: async (): Promise<Cable[]> => {
+      return await loadCables();
+    },
+  });
+
+  return cables;
+}

--- a/src/hooks/useIncidents.ts
+++ b/src/hooks/useIncidents.ts
@@ -1,0 +1,23 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export interface Incident {
+  date: string;
+  status: string;
+  cableid: string;
+  segment: string;
+  title: string;
+  description: string;
+  reparing_at: string;
+  resolved_at: string;
+}
+
+export function useIncidents() {
+  const { data: incidents } = useSuspenseQuery({
+    queryKey: ["incidents"],
+    queryFn: async (): Promise<Incident[]> => {
+      return await fetch("/data/incidents.json").then((res) => res.json());
+    },
+  });
+
+  return incidents;
+}

--- a/src/hooks/useIncidents.ts
+++ b/src/hooks/useIncidents.ts
@@ -15,7 +15,16 @@ export function useIncidents() {
   const { data: incidents } = useSuspenseQuery({
     queryKey: ["incidents"],
     queryFn: async (): Promise<Incident[]> => {
-      return await fetch("/data/incidents.json").then((res) => res.json());
+      try {
+        const res = await fetch("/data/incidents.json");
+        if (!res.ok) {
+          throw new Error(res.statusText);
+        }
+  
+        return await res.json();
+      } catch {
+        return [];
+      }
     },
   });
 

--- a/src/hooks/useTimelineSegments.ts
+++ b/src/hooks/useTimelineSegments.ts
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+
+export interface TimelineSegment {
+  startTime: Date;
+  endTime: Date;
+  status: 'online' | 'disconnected' | 'partial_disconnected' | 'notice';
+}
+
+export interface Incident {
+  date: string;
+  status: string;
+  cableid: string;
+  segment: string;
+  description: string;
+  resolved_at?: string;
+}
+
+export interface UseTimelineSegmentsProps {
+  cables: { id: string }[];
+  incidents: Incident[];
+  startDate: Date;
+  endDate: Date;
+}
+
+export function useTimelineSegments({ cables, incidents, startDate, endDate }: UseTimelineSegmentsProps) {
+  return useMemo(() => {
+    const newSegments: { [cableId: string]: TimelineSegment[] } = {};
+
+    // Initialize all cables as online for the entire period
+    cables.forEach(cable => {
+      newSegments[cable.id] = [{
+        startTime: startDate,
+        endTime: endDate,
+        status: 'online',
+      }];
+    });
+
+    // Add offline segments for incidents
+    incidents.forEach(incident => {
+      const cableId = incident.cableid;
+      if (!newSegments[cableId]) {
+        newSegments[cableId] = [{
+          startTime: startDate,
+          endTime: endDate,
+          status: 'online',
+        }];
+      }
+      // Find the online segment that contains this incident
+      const onlineSegment = newSegments[cableId].find(seg =>
+        seg.status === 'online' &&
+        new Date(incident.date) >= seg.startTime &&
+        new Date(incident.date) <= seg.endTime
+      );
+      if (onlineSegment) {
+        // Split the online segment into three parts: before, during, and after the incident
+        const incidentStart = new Date(incident.date);
+        const incidentEnd = incident.resolved_at ? new Date(incident.resolved_at) : endDate;
+        // Remove the original online segment
+        newSegments[cableId] = newSegments[cableId].filter(seg => seg !== onlineSegment);
+        // Add the three new segments
+        if (incidentStart > onlineSegment.startTime) {
+          newSegments[cableId].push({
+            startTime: onlineSegment.startTime,
+            endTime: incidentStart,
+            status: 'online',
+          });
+        }
+        newSegments[cableId].push({
+          startTime: incidentStart,
+          endTime: incidentEnd,
+          status: incident.status as TimelineSegment['status'],
+        });
+        if (incidentEnd < onlineSegment.endTime) {
+          newSegments[cableId].push({
+            startTime: incidentEnd,
+            endTime: onlineSegment.endTime,
+            status: 'online',
+          });
+        }
+      }
+    });
+    // Sort segments by start time for each cable
+    Object.keys(newSegments).forEach(cableId => {
+      newSegments[cableId].sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+    });
+    return newSegments;
+  }, [cables, incidents, startDate, endDate]);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,16 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
 import './utils/leaflet-patch.ts'
 
+const queryClient = new QueryClient()
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
Remove the duplicate logic for cables, incidents, and timeline segments. Additionally, the query can now be de-duplicated and effectively cached.

Also migrating to React [`<Suspense>`](https://react.dev/reference/react/Suspense).

Note that `useCable` and `useTimelineSegments` have not been thoroughly tested. It is advisable to test them with your real data.

![CleanShot 2025-06-16 at 00 58 17@2x](https://github.com/user-attachments/assets/16e5f580-696b-46dd-818d-3e0ab98affed)
